### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ paramiko
 pexpect==4.2.1
 sqlparse
 line_profiler
-whitenoise
+whitenoise==3.3.1
 dj_database_url
 psycopg2


### PR DESCRIPTION
固定whitenoise==3.3.1，没固定版本号时，默认安装最新版本到whitenoise 4，其中whitenoise 4的配置与此项目有冲突，导致按流程执行失败
![image](https://user-images.githubusercontent.com/11246158/54330668-8f2e9200-4651-11e9-80b3-e9d9a6d91c6a.png)
